### PR TITLE
CP-18658: Report on ovs rules for pvs proxy.

### DIFF
--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -567,6 +567,7 @@ let unplugged_vif = {
      Vif.active = false;
      plugged = false;
      kthread_pid = 0;
+     pvs_rules_active = false;
      media_present = false;
 }
 

--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -105,6 +105,8 @@ case $ACTION in
                         # Packets from server->client that need to be proxied.
                         ovs-ofctl --strict add-flow "$PVS_BRIDGE" priority=$((PVS_RULE_PRIO-1)),udp,dl_dst="$PVS_VM_MAC",nw_src="$PVS_SERVER_IP",tp_dst=$i,actions="$PVS_PROXY_OFPORT"
                     done
+					# Announce that on the OVS we have set up the rules for this VIF's pvs-proxy.
+					xenstore-write "${PRIVATE_PATH}/pvs-rules-active" ''
                 fi
             done
             unset IFS
@@ -156,6 +158,8 @@ case $ACTION in
                         # Packets from server->client that need to be proxied.
                         ovs-ofctl --strict del-flows "$PVS_BRIDGE" priority=$((PVS_RULE_PRIO-1)),udp,dl_dst="$PVS_VM_MAC",nw_src="$PVS_SERVER_IP",tp_dst=$i
                     done
+					# Announce that on the OVS we have removed the rules for this VIF's pvs-proxy.
+					xenstore-rm "${PRIVATE_PATH}/pvs-rules-active"
                 fi
             done
             unset IFS

--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -105,8 +105,8 @@ case $ACTION in
                         # Packets from server->client that need to be proxied.
                         ovs-ofctl --strict add-flow "$PVS_BRIDGE" priority=$((PVS_RULE_PRIO-1)),udp,dl_dst="$PVS_VM_MAC",nw_src="$PVS_SERVER_IP",tp_dst=$i,actions="$PVS_PROXY_OFPORT"
                     done
-					# Announce that on the OVS we have set up the rules for this VIF's pvs-proxy.
-					xenstore-write "${PRIVATE_PATH}/pvs-rules-active" ''
+                    # Announce that on the OVS we have set up the rules for this VIF's pvs-proxy.
+                    xenstore-write "${PRIVATE_PATH}/pvs-rules-active" ''
                 fi
             done
             unset IFS
@@ -158,8 +158,8 @@ case $ACTION in
                         # Packets from server->client that need to be proxied.
                         ovs-ofctl --strict del-flows "$PVS_BRIDGE" priority=$((PVS_RULE_PRIO-1)),udp,dl_dst="$PVS_VM_MAC",nw_src="$PVS_SERVER_IP",tp_dst=$i
                     done
-					# Announce that on the OVS we have removed the rules for this VIF's pvs-proxy.
-					xenstore-rm "${PRIVATE_PATH}/pvs-rules-active"
+                    # Announce that on the OVS we have removed the rules for this VIF's pvs-proxy.
+                    xenstore-rm "${PRIVATE_PATH}/pvs-rules-active"
                 fi
             done
             unset IFS

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -101,11 +101,6 @@ let disconnect_path_of_device ~xs (x: device) =
 let kthread_pid_path_of_device ~xs (x: device) =
 	sprintf "%s/kthread-pid" (backend_path_of_device ~xs x)
 
-(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
-  * script indicates whether the OVS rules are set up. *)
-let vif_pvs_rules_active_path_of_device ~xs (x: device) =
-	sprintf "%s/pvs-rules-active" (backend_path_of_device ~xs x)
-
 (** Location of the backend error path *)
 let backend_error_path_of_device ~xs (x : device) =
   sprintf "%s/error/backend/%s/%d"
@@ -185,6 +180,11 @@ let get_private_path_by_uuid uuid =
 
 let get_private_data_path_of_device (x: device) =
 	sprintf "%s/private/%s/%d" (get_private_path x.frontend.domid) (string_of_kind x.backend.kind) x.backend.devid
+
+(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
+  * script indicates whether the OVS rules are set up. *)
+let vif_pvs_rules_active_path_of_device ~xs (x: device) =
+	sprintf "%s/pvs-rules-active" (get_private_data_path_of_device x)
 
 (** Location of the device node's extra xenserver xenstore keys *)
 let extra_xenserver_path_of_device ~xs (x: device) =

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -101,6 +101,11 @@ let disconnect_path_of_device ~xs (x: device) =
 let kthread_pid_path_of_device ~xs (x: device) =
 	sprintf "%s/kthread-pid" (backend_path_of_device ~xs x)
 
+(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
+  * script indicates whether the OVS rules are set up. *)
+let vif_pvs_rules_active_path_of_device ~xs (x: device) =
+	sprintf "%s/pvs-rules-active" (backend_path_of_device ~xs x)
+
 (** Location of the backend error path *)
 let backend_error_path_of_device ~xs (x : device) =
   sprintf "%s/error/backend/%s/%d"

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -41,6 +41,7 @@ val frontend_rw_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val frontend_ro_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val disconnect_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val kthread_pid_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
+val vif_pvs_rules_active_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val error_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val backend_error_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2647,6 +2647,8 @@ module VIF = struct
 					let (d: Device_common.device) = device_by_id xc xs vm Device_common.Vif Newest (id_of vif) in
 					let path = Device_common.kthread_pid_path_of_device ~xs d in
 					let kthread_pid = try xs.Xs.read path |> int_of_string with _ -> 0 in
+					let pra_path = Device_common.vif_pvs_rules_active_path_of_device ~xs d in
+					let pvs_rules_active = try (ignore (xs.Xs.read pra_path); true) with _ -> false in
 					(* We say the device is present unless it has been deleted
 					   from xenstore. The corrolary is that: only when the device
 					   is finally deleted from xenstore, can we remove bridges or
@@ -2655,6 +2657,7 @@ module VIF = struct
 						Vif.active = true;
 						plugged = true;
 						media_present = true;
+						pvs_rules_active = pvs_rules_active;
 						kthread_pid = kthread_pid
 					}
 				with

--- a/xl/device_common.ml
+++ b/xl/device_common.ml
@@ -95,6 +95,11 @@ let kthread_pid_path_of_device ~xs (x: device) =
 		(string_of_kind x.backend.kind)
 		x.frontend.devid
 
+(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
+  * script indicates whether the OVS rules are set up. *)
+let vif_pvs_rules_active_path_of_device ~xs (x: device) =
+	sprintf "%s/pvs-rules-active" (backend_path_of_device ~xs x)
+
 (** Location of the backend error path *)
 let backend_error_path_of_device ~xs (x : device) =
   sprintf "%s/error/backend/%s/%d"

--- a/xl/device_common.ml
+++ b/xl/device_common.ml
@@ -95,11 +95,6 @@ let kthread_pid_path_of_device ~xs (x: device) =
 		(string_of_kind x.backend.kind)
 		x.frontend.devid
 
-(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
-  * script indicates whether the OVS rules are set up. *)
-let vif_pvs_rules_active_path_of_device ~xs (x: device) =
-	sprintf "%s/pvs-rules-active" (backend_path_of_device ~xs x)
-
 (** Location of the backend error path *)
 let backend_error_path_of_device ~xs (x : device) =
   sprintf "%s/error/backend/%s/%d"
@@ -165,6 +160,11 @@ let get_private_path_by_uuid uuid =
 
 let get_private_data_path_of_device (x: device) =
 	sprintf "%s/private/%s/%d" (get_private_path x.frontend.domid) (string_of_kind x.backend.kind) x.backend.devid
+
+(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
+  * script indicates whether the OVS rules are set up. *)
+let vif_pvs_rules_active_path_of_device ~xs (x: device) =
+	sprintf "%s/pvs-rules-active" (get_private_data_path_of_device x)
 
 let get_private_data_path_of_device_by_uuid uuid kind devid =
 	sprintf "%s/private/%s/%d" (get_private_path_by_uuid uuid) kind devid

--- a/xl/device_common.mli
+++ b/xl/device_common.mli
@@ -39,6 +39,7 @@ val backend_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val frontend_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val disconnect_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val kthread_pid_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
+val vif_pvs_rules_active_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val error_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val backend_error_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1649,6 +1649,8 @@ module VIF = struct
 					let (d: Device_common.device) = device_by_id xs vm Device_common.Vif Newest (id_of vif) in
 					let path = Device_common.kthread_pid_path_of_device ~xs d in
 					let kthread_pid = try xs.Xs.read path |> int_of_string with _ -> 0 in
+					let pra_path = Device_common.vif_pvs_rules_active_path_of_device ~xs d in
+					let pvs_rules_active = try (ignore (xs.Xs.read pra_path); true) with _ -> false in
 					(* We say the device is present unless it has been deleted
 					   from xenstore. The corrolary is that: only when the device
 					   is finally deleted from xenstore, can we remove bridges or
@@ -1657,6 +1659,7 @@ module VIF = struct
 						Vif.active = true;
 						plugged = true;
 						media_present = true;
+						pvs_rules_active = pvs_rules_active;
 						kthread_pid = kthread_pid
 					}
 				with


### PR DESCRIPTION
Read and write the pvs-rules-active xenstore node,
and include the information in the state passed up
to xapi.

Signed-off-by: Thomas Sanders thomas.sanders@citrix.com
