### PR TITLE
CA-245402/PAR-213: Use the right bridge in VIF.move

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1034,8 +1034,10 @@ let rec perform_atomic ~progress_callback ?subtask ?result (op: atomic) (t: Xeno
 			finally
 				(fun () ->
 					let vif = VIF_DB.read_exn id in
-					B.VIF.move t (VIF_DB.vm_of id) vif network;
-					VIF_DB.write id {vif with Vif.backend = network}
+					(* Nb, this VIF_DB write needs to come before the call to move
+					   as the scripts will read from the disk! *)
+					VIF_DB.write id {vif with Vif.backend = network};
+					B.VIF.move t (VIF_DB.vm_of id) vif network
 				) (fun () -> VIF_DB.signal id)
 		| VIF_set_carrier (id, carrier) ->
 			debug "VIF.set_carrier %s %b" (VIF_DB.string_of_id id) carrier;


### PR DESCRIPTION
Commit 39a09cbd move the responsibility for adding VIFs to bridges from
vif-real to setup-vif-rules. The inputs to these scripts are a little
different. For example, vif-real takes the bridge name from xenstore, while
setup-vif-rules reads it directly from xenopsd's runtime DB (JSON files on
disk). This means that we now need to make sure that this DB is up-to-date
before making any calls to the scripts. The same pattern was already used by
VIF.set_locking_mode.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
(cherry picked from commit 23a965d7b5cc1a676495a8b6ddb0f166808e57ba)

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>