### PR TITLE
Fix VIF.move for tap devices

### DIFF
--- a/xc/hotplug.ml
+++ b/xc/hotplug.ml
@@ -233,6 +233,7 @@ let run_hotplug_script device args =
 		"XENBUS_TYPE=" ^ kind;
 		"XENBUS_PATH=" ^ (Printf.sprintf "backend/%s/%d/%d" kind device.frontend.domid device.frontend.devid);
 		"XENBUS_BASE_PATH=backend";
+		"INTERFACE=" ^ (Printf.sprintf "%s%d.%d" kind device.frontend.domid device.frontend.devid);
 	|] ] in
 	try
 		debug "Running hotplug script %s %s" script (String.concat " " args);


### PR DESCRIPTION
The vif scripts expects the device name to be present in the INTERFACE
environment variable for tap device.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
(cherry picked from commit f9fafdbbe524a7f665fe4f1b41d242bd3f60d3ca)

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>