### PR TITLE
CA-269046: add "console/limit" key to xenstore for a domain

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -693,6 +693,7 @@ let build_linux (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~stati
 		"serial/0/limit",    string_of_int 65536;
 		"console/port",      string_of_int console_port;
 		"console/ring-ref",  sprintf "%nu" console_mfn;
+		"console/limit",     string_of_int 65536;
 	] in
 	let vm_stuff = [] in
 	build_post ~xc ~xs ~vcpus ~target_mib ~static_max_mib
@@ -774,6 +775,7 @@ let build_hvm (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~static_
 		"serial/0/limit",    string_of_int 65536;
 		"console/port",      string_of_int console_port;
 		"console/ring-ref",  sprintf "%nu" console_mfn;
+		"console/limit",     string_of_int 65536;
 	] in
 (*
 	let store_mfn =
@@ -993,6 +995,7 @@ let pv_restore (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~no_inc
 		"serial/0/limit",    string_of_int 65536;
 		"console/port",     string_of_int console_port;
 		"console/ring-ref", sprintf "%nu" console_mfn;
+		"console/limit",    string_of_int 65536;
 	] in
 	let vm_stuff = [] in
 	build_post ~xc ~xs ~vcpus ~target_mib ~static_max_mib
@@ -1028,6 +1031,7 @@ let hvm_restore (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~no_in
 		"serial/0/limit",    string_of_int 65536;
 		"console/port",     string_of_int console_port;
 		"console/ring-ref", sprintf "%nu" console_mfn;
+		"console/limit",    string_of_int 65536;
 	] in
 	let vm_stuff = [
 		"rtc/timeoffset",    timeoffset;


### PR DESCRIPTION
When we don't have this key present xenconsoled tends to
accumulate the output of guest PV consoles indefinitely if there
are no clients to consume it in Dom0. The problem manifests itself
when "disable_pv_vnc" parameter in other-config is set to 1 which
means there are no vncterm clients started for PV consoles.

Set this key to a reasonable limit of 64KB that will tell
xenconsoled to rotate the internal buffer instead of continously
increasing it.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>
Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>